### PR TITLE
Update go version to 1.25.7 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cybozu-go/login-protector
 
-go 1.24.3
+go 1.25.7
 
 require (
 	github.com/creack/pty v1.1.24


### PR DESCRIPTION
[`go 1.24.3` will be EOL](https://go.dev/doc/devel/release#policy), update go version in go.mod to `go 1.25.7`.

`go 1.25.7` is the latest version in cybozu/golang image:
https://github.com/cybozu/neco-containers/pkgs/container/golang/671831222?tag=1.25.7.1_noble

I executed the following command to update:

```bash
go mod tidy -go=1.25.7
```