### PR TITLE
Enable aqua checksum verification

### DIFF
--- a/.github/actions/aqua/action.yaml
+++ b/.github/actions/aqua/action.yaml
@@ -13,6 +13,3 @@ runs:
         # Disable the only-link flag so aqua downloads the tools and verifies their checksums
         aqua_opts: ""
         github_token: ${{ inputs.github_token }}
-      env:
-        # Verify module checksums during go install
-        GOSUMDB: sum.golang.org

--- a/.github/actions/aqua/action.yaml
+++ b/.github/actions/aqua/action.yaml
@@ -10,4 +10,9 @@ runs:
     - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c  # v4.0.4
       with:
         aqua_version: v2.57.1
+        # Disable the only-link flag so aqua downloads the tools and verifies their checksums
+        aqua_opts: ""
         github_token: ${{ inputs.github_token }}
+      env:
+        # Verify module checksums during go install
+        GOSUMDB: sum.golang.org

--- a/.github/actions/aqua/action.yaml
+++ b/.github/actions/aqua/action.yaml
@@ -10,6 +10,4 @@ runs:
     - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c  # v4.0.4
       with:
         aqua_version: v2.57.1
-        # Disable the only-link flag so aqua downloads the tools and verifies their checksums
-        aqua_opts: ""
         github_token: ${{ inputs.github_token }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the controller binary
-FROM ghcr.io/cybozu/golang:1.26-noble AS build
+FROM ghcr.io/cybozu/golang:1.26.2.2_noble@sha256:8154343edf8b656f4851572321483b8f304fa00b9966f1db687a7c1a3f234da8 AS build
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -1,0 +1,129 @@
+{
+  "checksums": [
+    {
+      "id": "github_release/github.com/golangci/golangci-lint/v2.11.4/golangci-lint-2.11.4-darwin-amd64.tar.gz",
+      "checksum": "C900D4048DB75D1EDFD550FD11CF6A9B3008E7CAA8E119FCDDBC700412D63E60",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/golangci/golangci-lint/v2.11.4/golangci-lint-2.11.4-darwin-arm64.tar.gz",
+      "checksum": "02DB2A2DAE8B26812E53B0688A6F617E3EF1F489790E829EA22862CF76945675",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/golangci/golangci-lint/v2.11.4/golangci-lint-2.11.4-linux-amd64.tar.gz",
+      "checksum": "200C5B7503F67B59A6743CCF32133026C174E272B930EE79AA2AA6F37ACA7EF1",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/golangci/golangci-lint/v2.11.4/golangci-lint-2.11.4-linux-arm64.tar.gz",
+      "checksum": "3BCFA2E6F3D32B2BF5CD75EAA876447507025E0303698633F722A05331988DB4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kind/v0.31.0/kind-darwin-amd64",
+      "checksum": "A8B3CF77B2AD77AEC5BF710D1A2589D9117576132AF812885CAD41E9DEDE4D4E",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kind/v0.31.0/kind-darwin-arm64",
+      "checksum": "88BF554FE9DA6311C9F8C2D082613C002911A476F6B5090E9420B35D84E70C5C",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kind/v0.31.0/kind-linux-amd64",
+      "checksum": "EB244CBAFCC157DFF60CF68693C14C9A75C4E6E6FEDAF9CD71C58117CB93E3FA",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kind/v0.31.0/kind-linux-arm64",
+      "checksum": "8E1014E87C34901CC422A1445866835D1E666F2A61301C27E722BDEAB5A1F7E4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_darwin_amd64.tar.gz",
+      "checksum": "EE7CF0C1E3592AA7BB66BA82B359933A95E7F2E0B36E5F53ED0A4535B017F2F8",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_darwin_arm64.tar.gz",
+      "checksum": "8886F8A78474E608CC81234F729FDA188A9767DA23E28925802F00ECE2BAB288",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_linux_amd64.tar.gz",
+      "checksum": "029A7F0F4E1932C52A0476CF02A0FD855C0BB85694B82C338FC648DCB53A819D",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/kubernetes-sigs/kustomize/kustomize/v5.8.1/kustomize_v5.8.1_linux_arm64.tar.gz",
+      "checksum": "0953EA3E476F66D6DDFCD911D750F5167B9365AA9491B2326398E289FEF2C142",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/ctlptl/v0.9.2/ctlptl.0.9.2.linux.arm64.tar.gz",
+      "checksum": "873436DF179ABF67CAAFBE4B6F0C5DC74861CC872F9B507BED6C2EDCA773058B",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/ctlptl/v0.9.2/ctlptl.0.9.2.linux.x86_64.tar.gz",
+      "checksum": "7F3E996D1CCB81A64ACB475500B497A2586F0F41E926461C924B8194C668E874",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/ctlptl/v0.9.2/ctlptl.0.9.2.mac.arm64.tar.gz",
+      "checksum": "24B0AD47913A097C75085BA99875056CED72C25E94097B868306B463C8A7EF8A",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/ctlptl/v0.9.2/ctlptl.0.9.2.mac.x86_64.tar.gz",
+      "checksum": "20A50DD51454BE4FDFB6041AB73B150033EB40E7DC7206F7541EC091158DFE4B",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/tilt/v0.37.1/tilt.0.37.1.linux.arm64.tar.gz",
+      "checksum": "70C6EAEDD1DF8D976FE10C8072B0535FC3B438F9BCFBDE17D994933EA566D2D4",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/tilt/v0.37.1/tilt.0.37.1.linux.x86_64.tar.gz",
+      "checksum": "38E8E353380F57C03124C2A1BA0728481C728027AC664C1B27A6BDB57F23BF07",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/tilt/v0.37.1/tilt.0.37.1.mac.arm64.tar.gz",
+      "checksum": "554E1084ADE12657FCB15C776DFCAEF58651CEF50764670837A2041F658E6516",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/tilt-dev/tilt/v0.37.1/tilt.0.37.1.mac.x86_64.tar.gz",
+      "checksum": "4EF2DAA6C182DA5597200B7B67750C82767DE40D3EBC0C629F972FA2F9FA46F8",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/dl.k8s.io/v1.35.4/bin/darwin/amd64/kubectl",
+      "checksum": "DDDB01BDDB96F78E48E33105CCFA2FEEDFF585A8B2E3B812F5D0F64C7403710A",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/dl.k8s.io/v1.35.4/bin/darwin/arm64/kubectl",
+      "checksum": "EC644A2473B64B486987F695DFB1867963CE6D42D267B86E944585A546F92B5D",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/dl.k8s.io/v1.35.4/bin/linux/amd64/kubectl",
+      "checksum": "B529430DF69A688FD61B64AD2299EDB5FD71CB58BE2A4779DBA624C7D3510EFD",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "http/dl.k8s.io/v1.35.4/bin/linux/arm64/kubectl",
+      "checksum": "6A5A4CC4E396D7626A7A693A3044B51C75520F81DB30FE6816C2554E53BE336F",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.496.0/registry.yaml",
+      "checksum": "4A04DA198765DDC0C008993BB455164ABE4A5D5FD7930CCC1DF3231557571DED",
+      "algorithm": "sha256"
+    }
+  ]
+}

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -9,6 +9,12 @@
 registries:
 - type: standard
   ref: v4.496.0
+checksum:
+  enabled: true
+  require_checksum: true
+  supported_envs:
+    - darwin
+    - linux
 packages:
 - name: kubernetes-sigs/kustomize@kustomize/v5.8.1
 - name: kubernetes-sigs/kind@v0.31.0


### PR DESCRIPTION
## Summary

- Enable checksum verification in `aqua.yaml` with `require_checksum: true` for both darwin and linux environments
- Add `aqua-checksums.json` with SHA256 checksums for all managed tools (golangci-lint, kind, kustomize, ctlptl, tilt, kubectl)
- Pin the base Docker image in `Dockerfile` to a specific digest to improve build reproducibility